### PR TITLE
Update XArray to version 0.20.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,21 +16,21 @@ build:
 requirements:
   host:
     # Drop support for python 3.6 https://github.com/pydata/xarray/pull/4720
-    - python >=3.7
+    - python
     - pip
-    - setuptools >=42
+    - setuptools
     - setuptools_scm_git_archive
-    - setuptools_scm >=3.4
+    - setuptools_scm
     - toml
     - wheel
 
   run:
     - python >=3.7
-    - numpy >=1.17
-    - pandas >=1.0
+    - numpy >=1.18
+    - pandas >=1.1
     # Drop support for python 3.6 https://github.com/pydata/xarray/pull/4720
     - setuptools >=40.4 # For pkg_resources
-    - typing-extensions
+    - typing-extensions >=3.7
 
 test:
   imports:
@@ -38,6 +38,7 @@ test:
     - xarray.backends
   requires:
     - pytest
+    - python <3.10
     - pip
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   noarch: python
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
@@ -20,7 +20,7 @@ requirements:
     - pip
     - setuptools
     - setuptools_scm_git_archive
-    - setuptools_scm
+    - setuptools_scm >=3.4
     - toml
     - wheel
 
@@ -30,6 +30,7 @@ requirements:
     - pandas >=1.1
     # Drop support for python 3.6 https://github.com/pydata/xarray/pull/4720
     - setuptools >=40.4 # For pkg_resources
+    - importlib-metadata
     - typing-extensions >=3.7
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.19.0" %}
+{% set version = "0.20.1" %}
 
 package:
   name: xarray
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/x/xarray/xarray-{{ version }}.tar.gz
-  sha256: 3a365ce09127fc841ba88baa63f37ca61376ffe389a6c5e66d52f2c88c23a62b
+  sha256: 9c0bffd8b55fdef277f8f6c817153eb51fa4e58653a7ad92eaed9984164b7bdb
 
 build:
   noarch: python


### PR DESCRIPTION

  `xarray` version `0.20.1`
1. check the upstream
https://github.com/pydata/xarray/tree/v0.20.1
2. check the pinnings
https://github.com/pydata/xarray/blob/v0.20.1/setup.py

https://github.com/pydata/xarray/blob/v0.20.1/setup.cfg

https://github.com/pydata/xarray/blob/v0.20.1/requirements.txt

https://github.com/pydata/xarray/blob/v0.20.1/pyproject.toml

3. check the changelogs

https://github.com/pydata/xarray/blob/v0.20.1/doc/whats-new.rst

4. additional research
   https://github.com/conda-forge/xarray-feedstock/issues
   
   There are currently no open issues in conda-forge

5. verify dev_url
    https://github.com/pydata/xarray

6. verify doc_url
    http://xarray.pydata.org/en/stable

7. pip in the test section
8. veriy the test section
9. additional tests

In order to test the `xarray` package version `0.20.1` the folowing
command was used:
`conda build xarray-feedstock --test`
the test result was the following:


Based on the research findings and the test results we can conclude
that .... to update `xarray` to version `0.20.1`

