### PR TITLE
xarray 2022.11.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.20.1" %}
+{% set version = "2022.11.0" %}
 
 package:
   name: xarray
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/x/xarray/xarray-{{ version }}.tar.gz
-  sha256: 9c0bffd8b55fdef277f8f6c817153eb51fa4e58653a7ad92eaed9984164b7bdb
+  sha256: 3008a302877f87a0f9043b1f01a4ad4e85b668bbdd38d488764098624632f527
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,45 +1,40 @@
+{% set name = "xarray" %}
 {% set version = "2022.11.0" %}
 
 package:
-  name: xarray
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/x/xarray/xarray-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 3008a302877f87a0f9043b1f01a4ad4e85b668bbdd38d488764098624632f527
 
 build:
-  noarch: python
   number: 0
+  skip:  True  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   host:
-    # Drop support for python 3.6 https://github.com/pydata/xarray/pull/4720
     - python
     - pip
     - setuptools
     - setuptools_scm_git_archive
-    - setuptools_scm >=3.4
+    - setuptools_scm
     - toml
     - wheel
 
   run:
-    - python >=3.7
-    - numpy >=1.18
-    - pandas >=1.1
-    # Drop support for python 3.6 https://github.com/pydata/xarray/pull/4720
-    - setuptools >=40.4 # For pkg_resources
-    - importlib-metadata
-    - typing-extensions >=3.7
+    - python
+    - numpy >=1.20
+    - pandas >=1.3
+    - packaging >=21.0
 
 test:
   imports:
     - xarray
     - xarray.backends
   requires:
-    - pytest
-    - python <3.10
     - pip
   commands:
     - pip check
@@ -50,6 +45,18 @@ about:
   license_file: LICENSE
   license_family: Apache
   summary: N-D labeled arrays and datasets in Python.
+  description: |
+    xarray (formerly xray) is an open source project and Python package
+    that makes working with labelled multi-dimensional arrays simple,
+    efficient, and fun!
+
+    xarray introduces labels in the form of dimensions, coordinates and
+    attributes on top of raw NumPy_-like arrays, which allows for a more
+    intuitive, more concise, and less error-prone developer experience.
+    The package includes a large and growing library of domain-agnostic functions for advanced analytics and visualization with these data structures.
+
+    xarray was inspired by and borrows heavily from pandas_, the popular data analysis package focused on labelled tabular data.
+    It is particularly tailored to working with netCDF_ files, which were the source of xarray's data model, and integrates tightly with dask_ for parallel computing.
   dev_url: https://github.com/pydata/xarray
   doc_url: http://xarray.pydata.org/en/stable
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,7 +58,7 @@ about:
     xarray was inspired by and borrows heavily from pandas_, the popular data analysis package focused on labelled tabular data.
     It is particularly tailored to working with netCDF_ files, which were the source of xarray's data model, and integrates tightly with dask_ for parallel computing.
   dev_url: https://github.com/pydata/xarray
-  doc_url: http://xarray.pydata.org/en/stable
+  doc_url: https://docs.xarray.dev/en/stable/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
**The upstream data:**
Github releases:  https://github.com/pydata/xarray/releases
[Diff between the latest and previous upstream releases](https://github.com/pydata/xarray/compare/0.20.1...2022.11.0)
License: https://github.com/pydata/xarray/blob/master/LICENSE
Requirements:
 * setup.cfg:  https://github.com/pydata/xarray/blob/v2022.11.0/setup.cfg
 * setup.py:  https://github.com/pydata/xarray/blob/v2022.11.0/setup.py
 *  pyproject.toml:  https://github.com/pydata/xarray/blob/v2022.11.0/pyproject.toml

**_Actions:_**

1. Remove `noarch`
2. Skip `py<38`
3. Update dependencies
4. Remove `pytest` and `python <3.10` from `test/requires`
5. Add description
6. Update doc url

**Package's statistics**
<details>

 * Priority C | effort: easy | Category: anaconda_affiliated_deps | subcategory:  | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 2022.11.0
 * Release on PyPi:
    * version: 2022.11.0
    * date: 2022-11-04T20:45:31
* [PyPi history](https://pypi.org/project/xarray/#history)
 * Popularity: 
    * 3 months downloads: 811971.0
    * All time:  6501678 downloads -  xarray  2022.11.0  N-D labeled arrays and datasets in Python.  

</details>

**Other checks:**

<details>

1. - [x] https://github.com/pydata/xarray/tree/v2022.11.0 exists
7. - [x] https://github.com/pydata/xarray is present
8. - [x] Check the pinnings
10. - [x] Additional research
    https://github.com/pydata/xarray/issues
    200
11. - [x] `dev_url` is present
    https://github.com/pydata/xarray
12. - [x] `doc_url` is present
13. - [x] Verify that the `build_number` is correct
14. - [x] Verify if the package needs `setuptools`
15. - [x] has `wheel`
16. - [x] `pip` in test
17. - [x] Verify the test section
18. - [x] Verify if the package is `architecture specific`
19. - [x] Verify that private modules are not mentioned in the recipe For example: (_private_module)
20.  - [x] license_file: LICENSE is present
21. - [x] License: Apache-2.0
    - [x] License is `spdx` compliant
 * Check if the license identifier has a correct name from the SPDX License List

| Identifier   |
|:-------------|
| Apache-2.0   |

22. - [x] license_family Apache is present
</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/xarray-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/xarray-feedstock/tree/2022.11.0)
* [conda-forge recipe](https://github.com/{upstream}/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/xarray)
* [Diff between upstream and feature branch](https://github.com/conda-forge/xarray-feedstock/compare/main...AnacondaRecipes:2022.11.0)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/xarray-feedstock/compare/master...AnacondaRecipes:2022.11.0)
* [The last merged PRs](https://github.com/AnacondaRecipes/xarray-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 2022.11.0 git@github.com:AnacondaRecipes/xarray-feedstock.git
```
