### PR TITLE
V2023.6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip:  True  # [py<38]
+  skip:  True  # [py<39]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,9 +26,9 @@ requirements:
 
   run:
     - python
-    - numpy >=1.20
-    - pandas >=1.3
-    - packaging >=21.0
+    - numpy >=1.21
+    - pandas >=1.4
+    - packaging >=21.3
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.20.1" %}
+{% set version = "2022.11.0" %}
 
 package:
   name: xarray
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/x/xarray/xarray-{{ version }}.tar.gz
-  sha256: 9c0bffd8b55fdef277f8f6c817153eb51fa4e58653a7ad92eaed9984164b7bdb
+  sha256: 3008a302877f87a0f9043b1f01a4ad4e85b668bbdd38d488764098624632f527
 
 build:
   noarch: python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   skip:  True  # [py<39]
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "xarray" %}
-{% set version = "2022.11.0" %}
+{% set version = "2023.6.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 3008a302877f87a0f9043b1f01a4ad4e85b668bbdd38d488764098624632f527
+  sha256: 267a231ee4efc0341ebbffc6d4ec60e4a66e4849c16e0305c03fcefeca77698c
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,9 +19,7 @@ requirements:
     - python
     - pip
     - setuptools
-    - setuptools_scm_git_archive
     - setuptools_scm
-    - toml
     - wheel
 
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,45 +1,40 @@
+{% set name = "xarray" %}
 {% set version = "2022.11.0" %}
 
 package:
-  name: xarray
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/x/xarray/xarray-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 3008a302877f87a0f9043b1f01a4ad4e85b668bbdd38d488764098624632f527
 
 build:
-  noarch: python
   number: 0
+  skip:  True  # [py<38]
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   host:
-    # Drop support for python 3.6 https://github.com/pydata/xarray/pull/4720
     - python
     - pip
     - setuptools
     - setuptools_scm_git_archive
-    - setuptools_scm >=3.4
+    - setuptools_scm
     - toml
     - wheel
 
   run:
-    - python >=3.7
-    - numpy >=1.18
-    - pandas >=1.1
-    # Drop support for python 3.6 https://github.com/pydata/xarray/pull/4720
-    - setuptools >=40.4 # For pkg_resources
-    - importlib-metadata
-    - typing-extensions >=3.7
+    - python
+    - numpy >=1.20
+    - pandas >=1.3
+    - packaging >=21.0
 
 test:
   imports:
     - xarray
     - xarray.backends
   requires:
-    - pytest
-    - python <3.10
     - pip
   commands:
     - pip check
@@ -50,6 +45,18 @@ about:
   license_file: LICENSE
   license_family: Apache
   summary: N-D labeled arrays and datasets in Python.
+  description: |
+    xarray (formerly xray) is an open source project and Python package
+    that makes working with labelled multi-dimensional arrays simple,
+    efficient, and fun!
+
+    xarray introduces labels in the form of dimensions, coordinates and
+    attributes on top of raw NumPy_-like arrays, which allows for a more
+    intuitive, more concise, and less error-prone developer experience.
+    The package includes a large and growing library of domain-agnostic functions for advanced analytics and visualization with these data structures.
+
+    xarray was inspired by and borrows heavily from pandas_, the popular data analysis package focused on labelled tabular data.
+    It is particularly tailored to working with netCDF_ files, which were the source of xarray's data model, and integrates tightly with dask_ for parallel computing.
   dev_url: https://github.com/pydata/xarray
   doc_url: http://xarray.pydata.org/en/stable
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -58,7 +58,7 @@ about:
     xarray was inspired by and borrows heavily from pandas_, the popular data analysis package focused on labelled tabular data.
     It is particularly tailored to working with netCDF_ files, which were the source of xarray's data model, and integrates tightly with dask_ for parallel computing.
   dev_url: https://github.com/pydata/xarray
-  doc_url: http://xarray.pydata.org/en/stable
+  doc_url: https://docs.xarray.dev/en/stable/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Upstream
Changelog

### Actions
- Updated version to 2023.6.0
- Updated dependencies
- Removed `setuptools_scm_git_archive` and `toml` from host section since they no longer seem to be used
- Linter fixes