### PR TITLE
PKG-14995: Update xarray to 2026.4.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,20 @@ requirements:
     - sparse >=0.15
     # viz
     - cartopy >=0.23
-    - matplotlib-base >=3.8
+# accel
+- scipy >=1.13
+- numbagg >=0.9
+- numba >=0.62
+- flox >=0.10
+# io
+- netcdf4 >=1.6.0
+- h5netcdf >=1.5.0
+- zarr >=3.0
+# etc
+- sparse >=0.15
+# viz
+- cartopy >=0.23
+- matplotlib-base >=3.8
 
 {% set deselect_tests = "" %}
 # hdf5 not build with szip support

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "xarray" %}
-{% set version = "2026.2.0" %}
+{% set version = "2026.4.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 978b6acb018770554f8fd964af4eb02f9bcc165d4085dbb7326190d92aa74bcf
+  sha256: c4ac9a01a945d90d5b1628e2af045099a9d4943536d4f2ee3ae963c3b222d15b
 
 build:
   number: 0
@@ -22,10 +22,8 @@ requirements:
     - setuptools_scm >=8
   run:
     - python
-    # numpy 2.4+ introduced behavior changes which may affect usage corner cases (affects visible in
-    # tests: test_curvefit_helpers, test_concat_periods). Added max cap to avoid the issue.
-    - numpy >=1.26,<2.4
-    - packaging >=24.1
+    - numpy >=1.26
+    - packaging >=24.2
     - pandas >=2.2
   run_constrained:
     # accel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,31 +28,18 @@ requirements:
   run_constrained:
     # accel
     - scipy >=1.13
-    - numbagg >=0.8
+    - numbagg >=0.9
     - numba >=0.62
-    - flox >=0.9
+    - flox >=0.10
     # io
     - netcdf4 >=1.6.0
-    - h5netcdf >=1.4.0
-    - zarr >=2.18
+    - h5netcdf >=1.5.0
+    - zarr >=3.0
     # etc
     - sparse >=0.15
     # viz
     - cartopy >=0.23
-# accel
-- scipy >=1.13
-- numbagg >=0.9
-- numba >=0.62
-- flox >=0.10
-# io
-- netcdf4 >=1.6.0
-- h5netcdf >=1.5.0
-- zarr >=3.0
-# etc
-- sparse >=0.15
-# viz
-- cartopy >=0.23
-- matplotlib-base >=3.8
+    - matplotlib-base >=3.8
 
 {% set deselect_tests = "" %}
 # hdf5 not build with szip support

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - pandas >=2.2
   run_constrained:
     # accel
-    - scipy >=1.13
+    - scipy >=1.15
     - numbagg >=0.9
     - numba >=0.62
     - flox >=0.10
@@ -39,7 +39,7 @@ requirements:
     - sparse >=0.15
     # viz
     - cartopy >=0.23
-    - matplotlib-base >=3.8
+    - matplotlib-base >=3.10
 
 {% set deselect_tests = "" %}
 # hdf5 not build with szip support


### PR DESCRIPTION
## xarray 2026.4.0

**Destination channel:** defaults

### Links
- [PKG-14995](https://anaconda.atlassian.net/browse/PKG-14995)
- [PyPI](https://pypi.org/project/xarray/2026.4.0/)
- [GitHub](https://github.com/pydata/xarray)

### Explanation of changes:
- Updated xarray from 2026.2.0 to 2026.4.0
- Removed `numpy <2.4` cap — xarray 2026.4.0 was released after numpy 2.4 and upstream does not cap it; the previous test failures (test_curvefit_helpers, test_concat_periods) should be resolved
- Bumped `packaging` from `>=24.1` to `>=24.2` (matching upstream)
- Update run_constrained

[PKG-14995]: https://anaconda.atlassian.net/browse/PKG-14995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ