### PR TITLE
xarray 2026.04.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: c4ac9a01a945d90d5b1628e2af045099a9d4943536d4f2ee3ae963c3b222d15b
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   skip:  true  # [py<311]
 
@@ -45,6 +45,7 @@ requirements:
 # hdf5 not build with szip support
 {% set deselect_tests = deselect_tests + " --deselect=test_backends.py::TestNetCDF4Data::test_compression_encoding" %}
 {% set deselect_tests = deselect_tests + " --deselect=test_backends_datatree.py::TestNetCDF4DataTree::test_compression_encoding" %}
+{% set deselect_tests = deselect_tests + " --deselect=test_backends.py::TestNetCDF4ViaDaskData::test_compression_encoding" %}
 
 {% set deselect_tests = deselect_tests + " --deselect=test_dataset.py::TestDataset::test_repr" %}
 
@@ -68,6 +69,10 @@ test:
     - pooch
     - scipy
     - netcdf4
+    # the anaconda metapackage has dask which provokes
+    # test_backends.py::TestNetCDF4ViaDaskData::test_compression_encoding[szip]
+    # so we want to deselect it
+    - dask
     - pytz
 
 about:


### PR DESCRIPTION
xarray 2026.04.0 

**Destination channel:** Defaults

### Links

- [PKG-15099]
- dev_url:        https://github.com/pydata/xarray
- conda_forge:    https://github.com/conda-forge/xarray-feedstock
- pypi:           https://pypi.org/project/xarray/2026.04.0
- pypi inspector: https://inspector.pypi.io/project/xarray/2026.04.0

### Explanation of changes:

- new build number
  - the `anaconda` metapackage has `dask` which provokes another `szip` test which fails -- so add `dask` to `test.requires` (to provoke the test) then deselect it


[PKG-15099]: https://anaconda.atlassian.net/browse/PKG-15099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ